### PR TITLE
Simplify exercise access using an exercise index

### DIFF
--- a/src/main/java/ch/uzh/ifi/access/course/controller/ExerciseController.java
+++ b/src/main/java/ch/uzh/ifi/access/course/controller/ExerciseController.java
@@ -1,0 +1,58 @@
+package ch.uzh.ifi.access.course.controller;
+
+import ch.uzh.ifi.access.course.dto.ExerciseWithSolutionsDTO;
+import ch.uzh.ifi.access.course.model.Exercise;
+import ch.uzh.ifi.access.course.service.CourseService;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/exercises")
+public class ExerciseController {
+
+    private final CourseService courseService;
+
+    public ExerciseController(CourseService courseService) {
+        this.courseService = courseService;
+    }
+
+    @GetMapping("/exercises/{exerciseId}")
+    public ResponseEntity<?> getExerciseByCourseAndAssignment(
+            @PathVariable("exerciseId") String exerciseId) {
+        Exercise ex = courseService.getExerciseById(exerciseId)
+                .orElseThrow(() -> new ResourceNotFoundException("No exercise found for id"));
+        if (ex.isPastDueDate()) {
+            return ResponseEntity.ok(new ExerciseWithSolutionsDTO(ex));
+        } else {
+            return ResponseEntity.ok(ex);
+        }
+    }
+
+    //TODO: Check if user has access to private & solution files
+    //TODO: Check if due date is up
+    @GetMapping("/{exerciseId}/files/{fileId}")
+    public ResponseEntity<Resource> getFile(
+            @PathVariable("exerciseId") String exerciseId,
+            @PathVariable("fileId") String fileId) throws IOException {
+        Optional<FileSystemResource> file = courseService.getFileByExerciseIdAndFileId(exerciseId, fileId);
+        if (file.isPresent()) {
+            File fileHandle = file.get().getFile();
+            FileSystemResource r = new FileSystemResource(fileHandle);
+            return ResponseEntity.ok()
+                    .contentType(MediaType.parseMediaType(Files.probeContentType(fileHandle.toPath())))
+                    .body(r);
+        }
+        return ResponseEntity.notFound().build();
+    }
+}

--- a/src/main/java/ch/uzh/ifi/access/course/controller/ExerciseController.java
+++ b/src/main/java/ch/uzh/ifi/access/course/controller/ExerciseController.java
@@ -27,7 +27,7 @@ public class ExerciseController {
         this.courseService = courseService;
     }
 
-    @GetMapping("/exercises/{exerciseId}")
+    @GetMapping("/{exerciseId}")
     public ResponseEntity<?> getExerciseByCourseAndAssignment(
             @PathVariable("exerciseId") String exerciseId) {
         Exercise ex = courseService.getExerciseById(exerciseId)

--- a/src/main/java/ch/uzh/ifi/access/course/model/Assignment.java
+++ b/src/main/java/ch/uzh/ifi/access/course/model/Assignment.java
@@ -33,27 +33,27 @@ public class Assignment {
         this.dueDate = other.dueDate;
     }
 
-    public void update(Assignment other){
+    public void update(Assignment other) {
         set(other);
 
         int diff = exercises.size() - other.exercises.size();
         int size = exercises.size();
-        if(diff > 0){
+        if (diff > 0) {
             // Deleted Assignment
-            for(int i = 0; i < Math.abs(diff); ++i){
-                exercises.remove(size - (i+1));
+            for (int i = 0; i < Math.abs(diff); ++i) {
+                exercises.remove(size - (i + 1));
             }
-        }else if(diff < 0){
+        } else if (diff < 0) {
             // Added assignment
-            for(int i = 0; i < Math.abs(diff); ++i){
+            for (int i = 0; i < Math.abs(diff); ++i) {
                 Exercise e = new Exercise();
                 e.set(other.exercises.get(size + i));
                 exercises.add(e);
             }
         }
 
-        for(int i = 0; i < exercises.size(); ++i){
-            if(exercises.get(i).hasChanged(other.exercises.get(i))){
+        for (int i = 0; i < exercises.size(); ++i) {
+            if (exercises.get(i).hasChanged(other.exercises.get(i))) {
                 exercises.get(i).update(other.exercises.get(i));
             }
         }
@@ -62,6 +62,12 @@ public class Assignment {
     public void addExercise(Exercise ex) {
         exercises.add(ex);
         ex.setAssignment(this);
+    }
+
+    public void addExercises(Exercise... exercises) {
+        for (Exercise ex : exercises) {
+            addExercise(ex);
+        }
     }
 
     public Optional<Exercise> findExerciseById(String id) {

--- a/src/main/java/ch/uzh/ifi/access/course/model/Course.java
+++ b/src/main/java/ch/uzh/ifi/access/course/model/Course.java
@@ -4,7 +4,9 @@ import ch.uzh.ifi.access.course.util.Utils;
 import lombok.Data;
 
 import java.time.LocalDateTime;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 @Data
 public class Course {
@@ -24,11 +26,11 @@ public class Course {
 
     private List<Assignment> assignments = new ArrayList<>();
 
-    public Course(){
+    public Course() {
         this.id = new Utils().getID();
     }
 
-    public void set(Course other){
+    public void set(Course other) {
         //this.directory = other.directory;
         this.gitHash = other.gitHash;
         this.title = other.title;
@@ -41,33 +43,39 @@ public class Course {
         this.students = other.students;
     }
 
-    public void update(Course other){
+    public void update(Course other) {
         set(other);
         int diff = assignments.size() - other.assignments.size();
         int size = assignments.size();
 
-        if(diff > 0){
+        if (diff > 0) {
             // Deleted Assignment
-            for(int i = 0; i < Math.abs(diff); ++i){
-                assignments.remove(size - (i+1));
+            for (int i = 0; i < Math.abs(diff); ++i) {
+                assignments.remove(size - (i + 1));
             }
-        }else if(diff < 0){
+        } else if (diff < 0) {
             // Added assignment
-            for(int i = 0; i < Math.abs(diff); ++i){
+            for (int i = 0; i < Math.abs(diff); ++i) {
                 Assignment a = new Assignment();
                 a.set(other.assignments.get(size + i));
                 assignments.add(a);
             }
         }
 
-        for(int i = 0; i < assignments.size(); ++i){
+        for (int i = 0; i < assignments.size(); ++i) {
             assignments.get(i).update(other.assignments.get(i));
         }
     }
 
-    public void addAssignment(Assignment a){
+    public void addAssignment(Assignment a) {
         a.setCourse(this);
         assignments.add(a);
+    }
+
+    public void addAssignments(Assignment... assignments) {
+        for (Assignment a : assignments) {
+            addAssignment(a);
+        }
     }
 
     public Optional<Assignment> getAssignmentById(String id) {

--- a/src/main/java/ch/uzh/ifi/access/course/service/CourseService.java
+++ b/src/main/java/ch/uzh/ifi/access/course/service/CourseService.java
@@ -1,18 +1,17 @@
 
 package ch.uzh.ifi.access.course.service;
 
-import ch.uzh.ifi.access.course.controller.ResourceNotFoundException;
-import ch.uzh.ifi.access.course.model.Assignment;
-import ch.uzh.ifi.access.course.model.Course;
 import ch.uzh.ifi.access.course.dao.CourseDAO;
+import ch.uzh.ifi.access.course.model.Course;
 import ch.uzh.ifi.access.course.model.Exercise;
+import ch.uzh.ifi.access.course.model.VirtualFile;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 @Service
 public class CourseService {
@@ -24,7 +23,9 @@ public class CourseService {
         this.courseDao = courseDao;
     }
 
-    public void updateCourses() {courseDao.updateCourse();}
+    public void updateCourses() {
+        courseDao.updateCourse();
+    }
 
     public List<Course> getAllCourses() {
         return courseDao.selectAllCourses();
@@ -40,9 +41,14 @@ public class CourseService {
                 .flatMap(assignment -> assignment.findExerciseById(exerciseId));
     }
 
-    public List<Assignment> getAllAssignmentsByCourseId() { return null;}
+    public Optional<Exercise> getExerciseById(String exerciseId) {
+        return courseDao.selectExerciseById(exerciseId);
+    }
 
-    public Optional<Course> getAssignmentByIdByCourseId(String id) {
-        return courseDao.selectCourseById(id);
+    public Optional<FileSystemResource> getFileByExerciseIdAndFileId(String exerciseId, String fileId) {
+        Optional<Exercise> exercise = getExerciseById(exerciseId);
+        Optional<VirtualFile> virtualFile = exercise.flatMap(e -> e.getFileById(fileId));
+
+        return virtualFile.map(file -> new FileSystemResource(file.getFile()));
     }
 }

--- a/src/test/java/ch/uzh/ifi/access/course/dao/CourseDAOTest.java
+++ b/src/test/java/ch/uzh/ifi/access/course/dao/CourseDAOTest.java
@@ -1,0 +1,66 @@
+package ch.uzh.ifi.access.course.dao;
+
+import ch.uzh.ifi.access.TestObjectFactory;
+import ch.uzh.ifi.access.course.model.Assignment;
+import ch.uzh.ifi.access.course.model.Course;
+import ch.uzh.ifi.access.course.model.Exercise;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class CourseDAOTest {
+
+    private CourseDAO courseDAO = new CourseDAO();
+
+    @Test
+    public void emptyExerciseIndex() {
+        Map<String, Exercise> exerciseMap = courseDAO.buildExerciseIndex(new ArrayList<>());
+        Assertions.assertThat(exerciseMap).isEmpty();
+    }
+
+    @Test
+    public void buildExerciseIndex() {
+        Course course = TestObjectFactory.createCourse("c");
+
+        Assignment a1 = TestObjectFactory.createAssignment("a1");
+        Assignment a2 = TestObjectFactory.createAssignment("a2");
+        Assignment a3 = TestObjectFactory.createAssignment("a23");
+        course.addAssignments(a1, a2, a3);
+
+        Exercise ex1 = TestObjectFactory.createCodeExercise("ex1");
+        Exercise ex2 = TestObjectFactory.createCodeExercise("ex2");
+        Exercise ex3 = TestObjectFactory.createCodeExercise("ex3");
+        Exercise ex4 = TestObjectFactory.createCodeExercise("ex4");
+        Exercise ex5 = TestObjectFactory.createCodeExercise("ex5");
+        Exercise ex6 = TestObjectFactory.createCodeExercise("ex6");
+
+        a1.addExercises(ex1, ex2);
+        a2.addExercise(ex3);
+        a3.addExercises(ex4, ex5, ex6);
+
+        Map<String, Exercise> exerciseMap = courseDAO.buildExerciseIndex(List.of(course));
+        Assertions.assertThat(exerciseMap).size().isEqualTo(6);
+        Assertions.assertThat(exerciseMap.get(ex1.getId())).isEqualTo(ex1);
+        Assertions.assertThat(exerciseMap.get(ex2.getId())).isEqualTo(ex2);
+        Assertions.assertThat(exerciseMap.get(ex3.getId())).isEqualTo(ex3);
+        Assertions.assertThat(exerciseMap.get(ex4.getId())).isEqualTo(ex4);
+        Assertions.assertThat(exerciseMap.get(ex5.getId())).isEqualTo(ex5);
+        Assertions.assertThat(exerciseMap.get(ex6.getId())).isEqualTo(ex6);
+    }
+
+    @Test
+    public void selectExerciseById() {
+        List<Course> courses = courseDAO.selectAllCourses();
+        for (Course c : courses) {
+            for (Assignment a : c.getAssignments()) {
+                for (Exercise e : a.getExercises()) {
+                    Exercise exercise = courseDAO.selectExerciseById(e.getId()).orElseThrow();
+                    Assertions.assertThat(exercise).isEqualTo(e);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added simplified endpoints to access exercise:

```
/api/exercises/{exerciseId}
/api/exercises/{exerciseId}/files/{fileId}
```

The old endpoints are still active to avoid breaking anything in the frontend at the moment