### PR TITLE
Bugfix/#88 question null

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,10 @@ jobs:
       TERM: dumb
 
     steps:
+      - run:
+          name: "What branch am I on?"
+          command: echo ${CIRCLE_BRANCH}
+
       - checkout
 
       - run:
@@ -68,7 +72,7 @@ jobs:
             chmod +x codacy-coverage-reporter
             ./codacy-coverage-reporter report -l Java -r build/reports/jacoco/test/jacocoTestReport.xml
 
-  deploy:
+  push_to_dockerhub:
     docker:
       - image: circleci/openjdk:11-jdk
     working_directory: ~/course_service
@@ -80,7 +84,7 @@ jobs:
 
       - run:
           name: Build Docker image
-          command: docker build -t hoal/$COURSE_SERVICE_IMAGE_NAME:latest .
+          command: docker build -t hoal/$COURSE_SERVICE_IMAGE_NAME:${CIRCLE_BRANCH} .
 
       - add_ssh_keys:
           fingerprints:
@@ -90,6 +94,13 @@ jobs:
           command: |
             echo $DOCKER_PWD | docker login -u $DOCKER_LOGIN --password-stdin
             docker push $DOCKER_USER/$COURSE_SERVICE_IMAGE_NAME:latest
+
+  deploy:
+    docker:
+      - image: circleci/openjdk:11-jdk
+    working_directory: ~/course_service
+
+    steps:
       - run:
           name: Deploy app to Digital Ocean Server via Docker
           command: |
@@ -100,6 +111,7 @@ workflows:
   build-and-deploy-master:
     jobs:
       - build
+      - push_to_dockerhub
       - deploy:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,9 +112,11 @@ workflows:
     jobs:
       - build
       - push_to_dockerhub
+          requires:
+          - build
       - deploy:
           requires:
-            - build
+            - push_to_dockerhub
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ workflows:
   build-and-deploy-master:
     jobs:
       - build
-      - push_to_dockerhub
+      - push_to_dockerhub:
           requires:
           - build
       - deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,7 @@ jobs:
   push_to_dockerhub:
     docker:
       - image: circleci/openjdk:11-jdk
+
     working_directory: ~/course_service
 
     steps:
@@ -84,7 +85,7 @@ jobs:
 
       - run:
           name: Print Docker image name
-          command: echo "hoal/$COURSE_SERVICE_IMAGE_NAME:$(echo $CIRCLE_BRANCH | tr -dc '[:alnum:]\n\r[-/]' | tr '[:upper:]' '[:lower:]')"
+          command: echo "hoal/$COURSE_SERVICE_IMAGE_NAME:$(echo $CIRCLE_BRANCH | tr -dc '[:alnum:]\n\r' | tr '[:upper:]' '[:lower:]')"
 
       - run:
           name: Build Docker image
@@ -97,7 +98,7 @@ jobs:
           name: Push Docker image
           command: |
             echo $DOCKER_PWD | docker login -u $DOCKER_LOGIN --password-stdin
-            docker push $DOCKER_USER/$COURSE_SERVICE_IMAGE_NAME:latest
+            docker push $DOCKER_USER/$COURSE_SERVICE_IMAGE_NAME:$(echo $CIRCLE_BRANCH | tr -dc '[:alnum:]\n\r' | tr '[:upper:]' '[:lower:]')
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
 
       - run:
           name: Build Docker image
-          command: docker build -t hoal/$COURSE_SERVICE_IMAGE_NAME:${CIRCLE_BRANCH} .
+          command: docker build -t hoal/$COURSE_SERVICE_IMAGE_NAME:$CIRCLE_BRANCH .
 
       - add_ssh_keys:
           fingerprints:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,8 +83,12 @@ jobs:
       - setup_remote_docker
 
       - run:
+          name: Print Docker image name
+          command: echo "hoal/$COURSE_SERVICE_IMAGE_NAME:$($CIRCLE_BRANCH | tr -dc '[:alnum:]\n\r[-/]' | tr '[:upper:]' '[:lower:]')"
+
+      - run:
           name: Build Docker image
-          command: docker build -t hoal/$COURSE_SERVICE_IMAGE_NAME:$CIRCLE_BRANCH .
+          command: docker build -t hoal/$COURSE_SERVICE_IMAGE_NAME:$($CIRCLE_BRANCH | tr -dc '[:alnum:]\n\r[-/]' | tr '[:upper:]' '[:lower:]') .
 
       - add_ssh_keys:
           fingerprints:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,11 +84,11 @@ jobs:
 
       - run:
           name: Print Docker image name
-          command: echo "hoal/$COURSE_SERVICE_IMAGE_NAME:$($CIRCLE_BRANCH | tr -dc '[:alnum:]\n\r[-/]' | tr '[:upper:]' '[:lower:]')"
+          command: echo "hoal/$COURSE_SERVICE_IMAGE_NAME:$(echo $CIRCLE_BRANCH | tr -dc '[:alnum:]\n\r[-/]' | tr '[:upper:]' '[:lower:]')"
 
       - run:
           name: Build Docker image
-          command: docker build -t hoal/$COURSE_SERVICE_IMAGE_NAME:$($CIRCLE_BRANCH | tr -dc '[:alnum:]\n\r[-/]' | tr '[:upper:]' '[:lower:]') .
+          command: docker build -t hoal/$COURSE_SERVICE_IMAGE_NAME:$(echo $CIRCLE_BRANCH | tr -dc '[:alnum:]\n\r[-/]' | tr '[:upper:]' '[:lower:]') .
 
       - add_ssh_keys:
           fingerprints:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
 
       - run:
           name: Build Docker image
-          command: docker build -t hoal/$COURSE_SERVICE_IMAGE_NAME:$(echo $CIRCLE_BRANCH | tr -dc '[:alnum:]\n\r-/' | tr '[:upper:]' '[:lower:]') .
+          command: docker build -t hoal/$COURSE_SERVICE_IMAGE_NAME:$(echo $CIRCLE_BRANCH | tr -dc '[:alnum:]\n\r' | tr '[:upper:]' '[:lower:]') .
 
       - add_ssh_keys:
           fingerprints:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
 
       - run:
           name: Build Docker image
-          command: docker build -t hoal/$COURSE_SERVICE_IMAGE_NAME:$(echo $CIRCLE_BRANCH | tr -dc '[:alnum:]\n\r[-/]' | tr '[:upper:]' '[:lower:]') .
+          command: docker build -t hoal/$COURSE_SERVICE_IMAGE_NAME:$(echo $CIRCLE_BRANCH | tr -dc '[:alnum:]\n\r-/' | tr '[:upper:]' '[:lower:]') .
 
       - add_ssh_keys:
           fingerprints:

--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,5 @@ gradle-app.setting
 
 
 course_repositories/
+
+courses_db

--- a/src/main/java/ch/uzh/ifi/access/course/RepoCacher.java
+++ b/src/main/java/ch/uzh/ifi/access/course/RepoCacher.java
@@ -94,7 +94,7 @@ public class RepoCacher {
             fis.read(data);
             fis.close();
             String content = new String(data, StandardCharsets.UTF_8);
-            logger.trace(String.format("Parsed file %s.\nContent:\n%s", file.getAbsolutePath(), content));
+            logger.trace(String.format("Parsed file %s\nContent:\n%s", file.getAbsolutePath(), content));
             return content;
         } catch (Exception e) {
             logger.warn(String.format("Failed to parse file %s", file.getAbsolutePath()), e);

--- a/src/main/java/ch/uzh/ifi/access/course/RepoCacher.java
+++ b/src/main/java/ch/uzh/ifi/access/course/RepoCacher.java
@@ -10,191 +10,197 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.internal.storage.file.FileRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class RepoCacher {
- 	private static final String REPO_DIR = "course_repositories";
 
-	// FOLDERS
-	private static final String ASSIGNMENT_FOLDER_PREFIX = "assignment";
-	private static final String EXERCISE_FOLDER_PREFIX = "exercise";
-	private static final String PUBLIC_FOLDER_NAME = "public";
-	private static final String PRIVATE_FOLDER_NAME = "private";
-	private static final String RESOURCE_FOLDER_NAME = "resource";
-	private static final String SOLUTION_FOLDER_NAME = "solution";
+    private static final Logger logger = LoggerFactory.getLogger(RepoCacher.class);
 
-	// FILES
-	private static final String COURSE_FILE_NAME = "config.json";
-	private static final String ASSIGNMENT_FILE_NAME = "config.json";
-	private static final String EXERCISE_FILE_NAME = "config.json";
-	private static final String QUESTION_FILE_NAME = "description.md";
+    private static final String REPO_DIR = "course_repositories";
 
-	private static ObjectMapper mapper;
+    // FOLDERS
+    private static final String ASSIGNMENT_FOLDER_PREFIX = "assignment";
+    private static final String EXERCISE_FOLDER_PREFIX = "exercise";
+    private static final String PUBLIC_FOLDER_NAME = "public";
+    private static final String PRIVATE_FOLDER_NAME = "private";
+    private static final String RESOURCE_FOLDER_NAME = "resource";
+    private static final String SOLUTION_FOLDER_NAME = "solution";
 
-	private List<String> ignore_dir = Arrays.asList(".git");
-	private List<String> ignore_file = Arrays.asList(".gitattributes", ".gitignore", "README.md");
+    // FILES
+    private static final String COURSE_FILE_NAME = "config.json";
+    private static final String ASSIGNMENT_FILE_NAME = "config.json";
+    private static final String EXERCISE_FILE_NAME = "config.json";
+    private static final String QUESTION_FILE_NAME = "description.md";
 
-    public static List<Course> retrieveCourseData(String urls[]) throws Exception
-    {
-		DateTimeFormatter fmt = new DateTimeFormatterBuilder()
-				.appendPattern("yyyy-MM-dd")
-				.optionalStart()
-				.appendPattern(" HH:mm")
-				.optionalEnd()
-				.parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
-				.parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
-				.toFormatter();
+    private static ObjectMapper mapper;
 
-		JavaTimeModule javaTimeModule = new JavaTimeModule();
-		LocalDateTimeDeserializer deserializer = new LocalDateTimeDeserializer(fmt);
-		javaTimeModule.addDeserializer(LocalDateTime.class, deserializer);
+    private List<String> ignore_dir = Arrays.asList(".git");
+    private List<String> ignore_file = Arrays.asList(".gitattributes", ".gitignore", "README.md");
 
-		mapper = new ObjectMapper();
-		mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    public static List<Course> retrieveCourseData(String urls[]) throws Exception {
+        DateTimeFormatter fmt = new DateTimeFormatterBuilder()
+                .appendPattern("yyyy-MM-dd")
+                .optionalStart()
+                .appendPattern(" HH:mm")
+                .optionalEnd()
+                .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+                .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+                .toFormatter();
+
+        JavaTimeModule javaTimeModule = new JavaTimeModule();
+        LocalDateTimeDeserializer deserializer = new LocalDateTimeDeserializer(fmt);
+        javaTimeModule.addDeserializer(LocalDateTime.class, deserializer);
+
+        mapper = new ObjectMapper();
+        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         mapper.registerModule(javaTimeModule);
 
-		List<Course> courses = new ArrayList<>();
+        List<Course> courses = new ArrayList<>();
 
-		int i = 0;
-        for(String url : urls) {
-			String hash = loadFilesFromGit(url);
+        int i = 0;
+        for (String url : urls) {
+            String hash = loadFilesFromGit(url);
 
-			RepoCacher cacher = new RepoCacher();
-			File repo = new File(REPO_DIR + "/" + nameFromGitURL(url));
-			Course course = new Course();
-			course.setGitHash(hash);
-			course.setDirectory(repo.getAbsolutePath());
-			course.setGitURL(url);
+            RepoCacher cacher = new RepoCacher();
+            File repo = new File(REPO_DIR + "/" + nameFromGitURL(url));
+            Course course = new Course();
+            course.setGitHash(hash);
+            course.setDirectory(repo.getAbsolutePath());
+            course.setGitURL(url);
 
-			cacher.cacheRepo(repo, course);
-			courses.add(course);
-		}
+            cacher.cacheRepo(repo, course);
+            courses.add(course);
+        }
         return courses;
     }
 
-	private static String readFile(File file){
-		try{
-			byte[] data = null;
-			FileInputStream fis = new FileInputStream(file);
-			data = new byte[(int) file.length()];
-			fis.read(data);
-			fis.close();
-			return new String(data, "UTF-8");
-		}catch(Exception e){
-			e.printStackTrace();	
-			return "";
-		}
-	}
-
-	private void cacheRepo(File file, Object context){
-		if (file.isDirectory()) 
-	  	{
-	  		if(ignore_dir.contains(file.getName())) return;
-
-	  		Object next_context = context;
-			if(file.getName().startsWith(ASSIGNMENT_FOLDER_PREFIX)){
-				Assignment assignment = new Assignment();
-				((Course)context).addAssignment(assignment);
-				next_context = assignment;
-			}else if(file.getName().startsWith(EXERCISE_FOLDER_PREFIX)){
-				Exercise exercise = new Exercise();
-				exercise.setGitHash(((Assignment)context).getCourse().getGitHash());
-				((Assignment)context).addExercise(exercise);
-				next_context = exercise;
-			}else if(file.getName().startsWith(PUBLIC_FOLDER_NAME)){
-				listFiles(file, ((Exercise)context).getPublic_files(), file.getPath());
-			}else if(file.getName().startsWith(PRIVATE_FOLDER_NAME)){
-				listFiles(file, ((Exercise)context).getPrivate_files(), file.getPath());
-			}else if(file.getName().startsWith(RESOURCE_FOLDER_NAME)){
-				listFiles(file, ((Exercise)context).getResource_files(), file.getPath());
-			}else if(file.getName().startsWith(SOLUTION_FOLDER_NAME)){
-				listFiles(file, ((Exercise)context).getSolution_files(), file.getPath());
-			}
-
-	    	String[] children = file.list(); 
-	    	for (int i=0; i < children.length; i++)
-	      		cacheRepo(new File(file, children[i]), next_context);
-	  	}else{
-			if(ignore_file.contains(file.getName())) return;
-
-			if(context instanceof Course) {
-				if(file.getName().equals(COURSE_FILE_NAME)){
-					try {
-						((Course)context).set(mapper.readValue(file, Course.class));
-					}catch(Exception e){
-						System.err.println("Error while parsing Course information: " + file.getName());
-						e.printStackTrace();
-					}
-				}
-			}else if(context instanceof Assignment) {
-				if(file.getName().equals(ASSIGNMENT_FILE_NAME)){
-					try {
-						((Assignment)context).set(mapper.readValue(file, Assignment.class));
-					}catch(Exception e){
-						System.err.println("Error while parsing Assignment information: " + file.getName());
-						e.printStackTrace();
-					}
-				}
-			}else if(context instanceof Exercise){
-				if(file.getName().equals(QUESTION_FILE_NAME)){
-					((Exercise)context).setQuestion(readFile(file));
-				}else if(file.getName().equals(EXERCISE_FILE_NAME)){
-					try {
-						((Exercise)context).set(mapper.readValue(file, Exercise.class));
-					}catch(Exception e){
-						System.err.println("Error while parsing Exercise information: " + file.getName());
-						e.printStackTrace();
-					}
-				}
-			}
-	  	}
+    private static String readFile(File file) {
+        try {
+            byte[] data = null;
+            FileInputStream fis = new FileInputStream(file);
+            data = new byte[(int) file.length()];
+            fis.read(data);
+            fis.close();
+            String content = new String(data, StandardCharsets.UTF_8);
+            logger.trace(String.format("Parsed file %s.\nContent:\n%s", file.getAbsolutePath(), content));
+            return content;
+        } catch (Exception e) {
+            logger.warn(String.format("Failed to parse file %s", file.getAbsolutePath()), e);
+            return "";
+        }
     }
 
-    private static void listFiles(File dir, List<VirtualFile> fileList, String root){
-		if (dir.isDirectory()){
-			String[] children = dir.list();
-			for (int i=0; i<children.length; i++)
-				listFiles(new File(dir, children[i]), fileList, root);
-		}else {
-			fileList.add(new VirtualFile(dir.getAbsolutePath(), dir.getPath().replace(root, "")));
-		}
-	}
+    private void cacheRepo(File file, Object context) {
+        if (file.isDirectory()) {
+            if (ignore_dir.contains(file.getName())) return;
 
-	private static boolean deleteDir(File dir)
-	{ 
-	  if (dir.isDirectory()) 
-	  { 
-	    String[] children = dir.list(); 
-	    for (int i=0; i<children.length; i++)
-	        deleteDir(new File(dir, children[i]));
-	  }
-	  return dir.delete(); 
-	}
+            Object next_context = context;
+            if (file.getName().startsWith(ASSIGNMENT_FOLDER_PREFIX)) {
+                Assignment assignment = new Assignment();
+                ((Course) context).addAssignment(assignment);
+                next_context = assignment;
+            } else if (file.getName().startsWith(EXERCISE_FOLDER_PREFIX)) {
+                Exercise exercise = new Exercise();
+                exercise.setGitHash(((Assignment) context).getCourse().getGitHash());
+                ((Assignment) context).addExercise(exercise);
+                next_context = exercise;
+            } else if (file.getName().startsWith(PUBLIC_FOLDER_NAME)) {
+                listFiles(file, ((Exercise) context).getPublic_files(), file.getPath());
+            } else if (file.getName().startsWith(PRIVATE_FOLDER_NAME)) {
+                listFiles(file, ((Exercise) context).getPrivate_files(), file.getPath());
+            } else if (file.getName().startsWith(RESOURCE_FOLDER_NAME)) {
+                listFiles(file, ((Exercise) context).getResource_files(), file.getPath());
+            } else if (file.getName().startsWith(SOLUTION_FOLDER_NAME)) {
+                listFiles(file, ((Exercise) context).getSolution_files(), file.getPath());
+            }
 
-	private static String nameFromGitURL(String url){
-    	return url.replace("https://github.com/", "").replace(".git", "");
-	}
+            String[] children = file.list();
+            for (int i = 0; i < children.length; i++)
+                cacheRepo(new File(file, children[i]), next_context);
+        } else {
+            if (ignore_file.contains(file.getName())) return;
 
-    private static String loadFilesFromGit(String url) throws Exception{
-    	File gitDir = new File(REPO_DIR + "/" + nameFromGitURL(url));
-    	if(gitDir.exists()){
-			new Git(new FileRepository(new File(REPO_DIR + "/" + nameFromGitURL(url) + "/.git")))
-					.pull()
-					.call();
-		}else {
-			Git.cloneRepository()
-					.setURI(url)
-					.setDirectory(gitDir)
-					.call();
-    	}
+            if (context instanceof Course) {
+                if (file.getName().equals(COURSE_FILE_NAME)) {
+                    try {
+                        ((Course) context).set(mapper.readValue(file, Course.class));
+                    } catch (Exception e) {
+                        System.err.println("Error while parsing Course information: " + file.getName());
+                        e.printStackTrace();
+                    }
+                }
+            } else if (context instanceof Assignment) {
+                if (file.getName().equals(ASSIGNMENT_FILE_NAME)) {
+                    try {
+                        ((Assignment) context).set(mapper.readValue(file, Assignment.class));
+                    } catch (Exception e) {
+                        System.err.println("Error while parsing Assignment information: " + file.getName());
+                        e.printStackTrace();
+                    }
+                }
+            } else if (context instanceof Exercise) {
+                if (file.getName().equals(QUESTION_FILE_NAME)) {
+                    ((Exercise) context).setQuestion(readFile(file));
+                } else if (file.getName().equals(EXERCISE_FILE_NAME)) {
+                    try {
+                        ((Exercise) context).set(mapper.readValue(file, Exercise.class));
+                    } catch (Exception e) {
+                        System.err.println("Error while parsing Exercise information: " + file.getName());
+                        e.printStackTrace();
+                    }
+                }
+            }
+        }
+    }
 
-    	return (new FileRepository(new File(REPO_DIR + "/" + nameFromGitURL(url) + "/.git")).getAllRefs().get("HEAD").getObjectId().getName());
-	}
- }
+    private static void listFiles(File dir, List<VirtualFile> fileList, String root) {
+        if (dir.isDirectory()) {
+            String[] children = dir.list();
+            for (int i = 0; i < children.length; i++)
+                listFiles(new File(dir, children[i]), fileList, root);
+        } else {
+            fileList.add(new VirtualFile(dir.getAbsolutePath(), dir.getPath().replace(root, "")));
+        }
+    }
+
+    private static boolean deleteDir(File dir) {
+        if (dir.isDirectory()) {
+            String[] children = dir.list();
+            for (int i = 0; i < children.length; i++)
+                deleteDir(new File(dir, children[i]));
+        }
+        return dir.delete();
+    }
+
+    private static String nameFromGitURL(String url) {
+        return url.replace("https://github.com/", "").replace(".git", "");
+    }
+
+    private static String loadFilesFromGit(String url) throws Exception {
+        File gitDir = new File(REPO_DIR + "/" + nameFromGitURL(url));
+        if (gitDir.exists()) {
+            new Git(new FileRepository(new File(REPO_DIR + "/" + nameFromGitURL(url) + "/.git")))
+                    .pull()
+                    .call();
+        } else {
+            Git.cloneRepository()
+                    .setURI(url)
+                    .setDirectory(gitDir)
+                    .call();
+        }
+
+        return (new FileRepository(new File(REPO_DIR + "/" + nameFromGitURL(url) + "/.git")).getAllRefs().get("HEAD").getObjectId().getName());
+    }
+}

--- a/src/main/java/ch/uzh/ifi/access/course/model/Exercise.java
+++ b/src/main/java/ch/uzh/ifi/access/course/model/Exercise.java
@@ -3,7 +3,6 @@ package ch.uzh.ifi.access.course.model;
 import ch.uzh.ifi.access.course.util.Utils;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
-import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,11 +38,6 @@ public class Exercise {
     public void set(Exercise other) {
         this.type = other.type;
         this.language = other.language;
-
-        if (StringUtils.isEmpty(this.question)) {
-            this.question = other.question;
-        }
-
         this.maxSubmits = other.maxSubmits;
     }
 
@@ -54,6 +48,7 @@ public class Exercise {
         this.public_files = other.public_files;
         this.solution_files = other.solution_files;
         this.resource_files = other.resource_files;
+        this.question = other.question;
     }
 
     public Optional<VirtualFile> getFileById(String id) {

--- a/src/main/java/ch/uzh/ifi/access/course/model/Exercise.java
+++ b/src/main/java/ch/uzh/ifi/access/course/model/Exercise.java
@@ -3,6 +3,7 @@ package ch.uzh.ifi.access.course.model;
 import ch.uzh.ifi.access.course.util.Utils;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
+import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,20 +30,24 @@ public class Exercise {
     private List<VirtualFile> solution_files = new ArrayList<>();
 
     private List<VirtualFile> resource_files = new ArrayList<>();
-    private List<VirtualFile> public_files= new ArrayList<>();
+    private List<VirtualFile> public_files = new ArrayList<>();
 
-    public Exercise(){
+    public Exercise() {
         this.id = new Utils().getID();
     }
 
-    public void set(Exercise other){
+    public void set(Exercise other) {
         this.type = other.type;
         this.language = other.language;
-        this.question = other.question;
+
+        if (StringUtils.isEmpty(this.question)) {
+            this.question = other.question;
+        }
+
         this.maxSubmits = other.maxSubmits;
     }
 
-    public void update(Exercise other){
+    public void update(Exercise other) {
         set(other);
         this.gitHash = other.gitHash;
         this.private_files = other.private_files;
@@ -51,17 +56,17 @@ public class Exercise {
         this.resource_files = other.resource_files;
     }
 
-    public Optional<VirtualFile> getFileById(String id){
+    public Optional<VirtualFile> getFileById(String id) {
         //TODO: Also search in private files
         Stream<VirtualFile> files = Stream.concat(Stream.concat(public_files.stream(), resource_files.stream()), solution_files.stream());
         return files.filter(file -> file.getId().equals(id)).findFirst();
     }
 
-    public boolean isPastDueDate(){
+    public boolean isPastDueDate() {
         return assignment.isPastDueDate();
     }
 
-    public boolean hasChanged(Exercise other){
+    public boolean hasChanged(Exercise other) {
         return !(Objects.equals(this.type, other.type) &&
                 Objects.equals(this.language, other.language) &&
                 Objects.equals(this.question, other.question) &&

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,6 +14,7 @@ rest.security.authorization-endpoint=${rest.security.issuer-uri}/protocol/openid
 security.oauth2.resource.id=course-service
 security.oauth2.resource.jwk.key-set-uri=${rest.security.issuer-uri}/protocol/openid-connect/certs
 # Others
+logging.level.ch.uzh.ifi.access.course.RepoCacher=trace
 logging.level.ch.uzh.ifi.access.course.config=debug
 logging.level.ch.uzh.ifi.access.keycloak.KeycloakClient=debug
 server.servlet.context-path=/api

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,7 +14,6 @@ rest.security.authorization-endpoint=${rest.security.issuer-uri}/protocol/openid
 security.oauth2.resource.id=course-service
 security.oauth2.resource.jwk.key-set-uri=${rest.security.issuer-uri}/protocol/openid-connect/certs
 # Others
-logging.level.ch.uzh.ifi.access.course.RepoCacher=trace
 logging.level.ch.uzh.ifi.access.course.config=debug
 logging.level.ch.uzh.ifi.access.keycloak.KeycloakClient=debug
 server.servlet.context-path=/api


### PR DESCRIPTION
If an exercise contains both config.json and question.md, one will end up overwriting the other.
Don't know why this does not happen locally though.

`Exercise#set(Exercise other)` overwrites the question with the value read from config.json (which is non-existent)
https://github.com/mp-access/Course-Service/blob/ace497116b64078a62f934eb0d4fbc5150c3a13b/src/main/java/ch/uzh/ifi/access/course/RepoCacher.java#L153-L158